### PR TITLE
fix(ci): pin release-please action commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: python
           package-name: aruba-ssid-manager


### PR DESCRIPTION
## Summary
- Pin release-please-action v5 to the peeled action commit SHA.
- Replace the annotated tag object SHA that can fail action resolution.

## Linked Issue
Related to #17

## Testing Evidence
```text
GitHub Actions runs on this PR. Release workflow path is not executed on pull_request.
```

## Security and Release Checklist
- [x] Workflow action is pinned to an immutable commit SHA.
- [x] No production code or secrets changed.
- [x] Release automation behavior is preserved.